### PR TITLE
Convert background removal to single button

### DIFF
--- a/HansRoslinger/imports/ui/App.tsx
+++ b/HansRoslinger/imports/ui/App.tsx
@@ -72,17 +72,17 @@ export const App: React.FC = () => {
 
   return (
     <div className="relative w-screen h-screen overflow-hidden">
-      {/* Fullscreen video */}
+            {/* Fullscreen video */}
       <div
         className={`absolute inset-0 flex flex-col items-center justify-center ${backgroundRemoval ? "invisible pointer-events-none" : ""}`}
       >
         <WebcamComponent grayscale={grayscale} />
       </div>
-      {backgroundRemoval && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center">
-          <ImageSegmentation grayscale={grayscale} />
-        </div>
-      )}
+      <div
+        className={`absolute inset-0 flex flex-col items-center justify-center ${!backgroundRemoval ? "invisible pointer-events-none" : ""}`}
+      >
+        <ImageSegmentation grayscale={grayscale} />
+      </div>
 
       {isZoomEnabled && zoomStartPosition && (
         <div
@@ -122,6 +122,8 @@ export const App: React.FC = () => {
             onToggleGrayscale={() => setGrayscale((g) => !g)}
             showLineChart={showLineChart}
             onToggleChart={() => setShowLineChart((c) => !c)}
+            backgroundRemoval={backgroundRemoval}
+            grayscale={grayscale}
           />
         )}
         <button

--- a/HansRoslinger/imports/ui/Header.tsx
+++ b/HansRoslinger/imports/ui/Header.tsx
@@ -5,6 +5,8 @@ interface HeaderProps {
   onToggleGrayscale: () => void;
   showLineChart: boolean;
   onToggleChart: () => void;
+  backgroundRemoval: boolean;
+  grayscale: boolean;
 }
 
 export const Header: React.FC<HeaderProps> = ({
@@ -12,25 +14,30 @@ export const Header: React.FC<HeaderProps> = ({
   onToggleGrayscale,
   showLineChart,
   onToggleChart,
+  backgroundRemoval,
+  grayscale,
 }) => (
   <>
     {/* Background removal enable */}
     <button
-      id="background-removal-enable"
-      className="w-10 h-10 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm font-medium text-white"
-    >
-      EBR
-    </button>
-    <button
       onClick={onToggleBackgroundRemoval}
-      className="w-10 h-10 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm font-medium text-white"
+      id="background-removal-enable"
+      className={`w-10 h-10 rounded-lg text-sm font-medium ${
+        backgroundRemoval
+          ? "bg-cyan-400 hover:bg-cyan-300 text-black"
+          : "bg-gray-700 hover:bg-gray-600 text-white"
+      }`}
     >
       BR
     </button>
     {/* Grayscale toggle */}
     <button
       onClick={onToggleGrayscale}
-      className="w-10 h-10 rounded-lg bg-gray-700 hover:bg-gray-600 text-sm font-medium text-white"
+      className={`w-10 h-10 rounded-lg text-sm font-medium ${
+        grayscale
+          ? "bg-cyan-400 hover:bg-cyan-300 text-black"
+          : "bg-gray-700 hover:bg-gray-600 text-white"
+      }`}
     >
       GS
     </button>

--- a/HansRoslinger/imports/ui/Video/ImageSegmentation/ImageSegmentation.tsx
+++ b/HansRoslinger/imports/ui/Video/ImageSegmentation/ImageSegmentation.tsx
@@ -149,10 +149,8 @@ export const ImageSegmentation: React.FC<ImageSegmentationProps> = () => {
 
       if (webcamRunning === true) {
         webcamRunning = false;
-        enableWebcamButton.innerText = "EBR";
       } else {
         webcamRunning = true;
-        enableWebcamButton.innerText = "DBR";
       }
 
       // getUsermedia parameters.


### PR DESCRIPTION
## Changes
- background removal can now be enabled/disabled with a single button
- buttons turn cyan when selected

## Description
I've updated it so the image segmentation component is made invisible instead of being removed, that way it can always be "loaded" (in the sense that it exists not that it's using up processing) and then made visible and enabled with a single button

## Checklist
- [ ] feature
- [ ] bug
- [X] chore

## Notes
- Please verify all CI workflows are successfully running before requesting a review
- Please refer to the [Quality Assurance Plan](https://docs.google.com/document/d/1_3e-gP3NBhk1eZQoM0hvVHZOP-jfldTV) for details on what is expected of a Pull Request